### PR TITLE
Plymouth as new default

### DIFF
--- a/data/ENHANCED-BASIS
+++ b/data/ENHANCED-BASIS
@@ -61,8 +61,8 @@ tar
 wget
 // split out of ncurses
 ncurses-utils
-// we want a branded boot (bnc#385502)
-bootsplash-branding-openSUSE
+// we want a branded boot
+plymouth-branding-openSUSE
 // #302569
 alsa-plugins
 // useful for debugging
@@ -79,7 +79,8 @@ deltarpm
 acpid
 autofs
 bind-utils
-bootsplash
+// Make plymouth the new default bootsplash
+plymouth
 cyrus-sasl
 dosfstools
 gawk


### PR DESCRIPTION
As discussed on IRC, Plymouth has been in Factory for some time and all known bugs have been resolved. We have an initial version of an openSUSE branding which works well and integrated with LUKS, etc. Therefore the time is now to make Plymouth the default for installations and see what other bugs might appear. :)

Raymond
