### PR TITLE
Bug 754959 - add hyper-v.rpm to install media

### DIFF
--- a/data/ENHANCED-BASIS-OPT
+++ b/data/ENHANCED-BASIS-OPT
@@ -20,6 +20,10 @@ hfsutils
 #if defined(__i386__) || defined (__x86_64__)
 haveged
 #endif
+// 754959
+#if defined(__i386__) || defined (__x86_64__)
+hyper-v
+#endif
 irqbalance
 joe
 ksh


### PR DESCRIPTION
The hv_kvp_daemon provides info about the guest to the host.
In upcoming versions it will also allow the host to push configuration
changes into the guest. Make sure the package is on the media.
hyper-v.rpm will automatically selected for installation in a hyper-v guest.
