### PR TITLE
Add xchat to REST-CD-X11 pattern

### DIFF
--- a/data/REST-CD-X11
+++ b/data/REST-CD-X11
@@ -18,4 +18,5 @@ epdfview
 gparted
 photorec
 ristretto
+xchat
 -Prc:


### PR DESCRIPTION
IRC is an important support channel, and xchat seems to be the best option available, this will drag in gconf2, gconf2-branding-openSUSE and gconf-polkit
