### PR TITLE
keep up with changing package names

### DIFF
--- a/data/GNOME-DESKTOP
+++ b/data/GNOME-DESKTOP
@@ -20,10 +20,10 @@ eog
 evince
 evolution
 file-roller
-gcalctool
 gcr-viewer
 gedit
 gnome-bluetooth
+gnome-calculator
 gnome-contacts
 gnome-dictionary
 gnome-documents

--- a/data/GNOME-Utilities
+++ b/data/GNOME-Utilities
@@ -9,8 +9,8 @@ patterns-openSUSE-gnome_utilities
 baobab
 cheese
 file-roller
-gcalctool
 gedit
+gnome-calculator
 gnome-dictionary
 gnome-font-viewer
 gnome-screenshot


### PR DESCRIPTION
- gcalctool -> gnome-calculator
- gnome-shell-extension-alt-status-menu -> gnome-shell-extension-alternative-status-menu
- drop hamster-applet; replaced with hamster-time-tracker long ago, but don't want that by default
