### PR TITLE
Remove xvkbd from laptop, add eekboard to tablet (try 2)

### DIFF
--- a/data/LAPTOP
+++ b/data/LAPTOP
@@ -9,7 +9,6 @@ wpa_supplicant
 crda
 wireless-regdb
 iw
-xvkbd
 -Prc:
 +Psg:
 irda

--- a/data/TABLETPC
+++ b/data/TABLETPC
@@ -8,5 +8,5 @@ xorg-x11-driver-input
 wacom-kmp
 xournal
 xstroke
-xvkbd
+eekboard
 -Prc:


### PR DESCRIPTION
Please remove xvkbd from the default laptop install, it's hideous! eekboard seems like a good alternative.

This request adds eekboard to the tablet pattern and removes xvkbd from both laptop and tablet.
