### PR TITLE
Add libvirt-daemon-xen to the xen_server pattern

### DIFF
--- a/data/XEN
+++ b/data/XEN
@@ -17,6 +17,7 @@ xen-doc-pdf
 xterm
 yast2-vm
 virt-viewer
+libvirt-daemon-xen
 -Prc:
 +Psg:
 // #382423


### PR DESCRIPTION
Recent decomposition of the libvirt package requires installing
a hypervisor-specific libvirtd.  In the case of Xen, this should
be libvirt-daemon-xen.
