### PR TITLE
AppArmor pattern - don't install pam_apparmor when just selecting the pattern

### DIFF
--- a/data/APPARMOR
+++ b/data/APPARMOR
@@ -8,5 +8,8 @@ audit
 +Prc:
 yast2-apparmor
 apparmor-utils
-pam_apparmor
 -Prc:
+
++Psg:
+pam_apparmor
+-Psg:


### PR DESCRIPTION
change the AppArmor pattern - pam_apparmor should still be listed, but
it shouldn't be installed if someone just selects the AppArmor pattern.
(In rpm speak: change the recommends: to suggests:)

I hope google found the correct page describing the pattern syntax ;-)
