### PR TITLE
Remove xen-doc-pdf

### DIFF
--- a/data/XEN
+++ b/data/XEN
@@ -13,7 +13,6 @@ kernel-xen
 #endif
 virt-manager
 xen-doc-html
-xen-doc-pdf
 xterm
 yast2-vm
 virt-viewer


### PR DESCRIPTION
The xen-doc-pdf package has been removed in Factory.  Remove it
from the xen_server pattern as well.
