### PR TITLE
devel c(++): move ddd to suggests

### DIFF
--- a/data/DEVEL-C-C++
+++ b/data/DEVEL-C-C++
@@ -5,13 +5,13 @@ patterns-openSUSE-devel_C_C++
 glibc-info
 boost-devel
 boost-jam
-ddd
 posix_cc
 swig
 valgrind
 ltrace
 -Prc:
 +Psg:
+ddd
 // 403368
 dejagnu
 expect


### PR DESCRIPTION
The UI is from the 90s; it should not be a default
