### PR TITLE
GNOME: Remove several old packages and add gnome-photos to suggests

### DIFF
--- a/data/GNOME-ADMIN
+++ b/data/GNOME-ADMIN
@@ -9,6 +9,4 @@ vinagre
 -Prc:
 
 +Psg:
-pessulus
-sabayon
 -Psg:

--- a/data/GNOME-BASIS
+++ b/data/GNOME-BASIS
@@ -18,10 +18,6 @@ gnome-session-fallback-session
 // default
 gnome-settings-daemon
 gnome-shell
-// fallback
-gnome-panel
-metacity
-notification-daemon
 //
 // Low-level parts that we need
 //
@@ -89,5 +85,4 @@ libgnomesu
 -Prc:
 
 +Psg:
-gnome-applets
 -Psg:

--- a/data/GNOME-BASIS-OPT
+++ b/data/GNOME-BASIS-OPT
@@ -1,10 +1,7 @@
 +Prc:
-gnome-applets
 // #394406
 dynamic-wallpaper-branding-openSUSE
 -Prc:
 
 +Psg:
-// #301664 -> suggests due to 380248
-gnome-commander
 -Psg:

--- a/data/GNOME-DESKTOP
+++ b/data/GNOME-DESKTOP
@@ -75,7 +75,6 @@ telepathy-sofiasip
 dasher
 gconf-editor
 gnome-backgrounds
-gnome-media
 // bnc#698250
 gnome-color-manager
 -Psg:

--- a/data/GNOME-IMAGE
+++ b/data/GNOME-IMAGE
@@ -16,4 +16,5 @@ simple-scan
 
 +Psg:
 f-spot
+gnome-photos
 -Psg:

--- a/data/GNOME-LAPTOP
+++ b/data/GNOME-LAPTOP
@@ -4,8 +4,6 @@ patterns-openSUSE-gnome_laptop
 
 +Prc:
 gnome-bluetooth
-// bnc#372208
-gnome-phone-manager
 -Prc:
 
 +Psg:

--- a/data/GNOME-Multimedia
+++ b/data/GNOME-Multimedia
@@ -32,15 +32,10 @@ rhythmbox
 
 +Psg:
 //
-// Official upstream
-//
-gnome-media
-//
 // Packages that really make sense
 //
 paprefs
 pavucontrol
 pitivi
-rhythmbox
 sound-juicer
 -Psg:

--- a/data/GNOME-Office
+++ b/data/GNOME-Office
@@ -17,7 +17,6 @@ libreoffice-icon-theme-tango
 +Psg:
 abiword
 evolution-ews
-evolution-groupwise
 glabels
 gnumeric
 pinpoint

--- a/data/GNOME-Utilities
+++ b/data/GNOME-Utilities
@@ -26,8 +26,6 @@ gnome-tweak-tool
 // thumbnailing in nautilus
 gnome-web-photo
 gsf-office-thumbnailer
-// open terminal from RMB on desktop
-nautilus-open-terminal
 -Prc:
 
 +Psg:


### PR DESCRIPTION
Remove GNOME 2.x / fallback / not-existing-anymore package:
- evolution-groupwise (not existing)
- gnome-applets (fallback)
- gnome-commander (doesn't fit GNOME 3)
- gnome-media (not existing)
- gnome-panel (fallback)
- gnome-phone-manager (useless nowadays)
- metacity (fallback)
- nautilus-open-terminal (not existing)
- notification-daemon (fallback)
- pessulus (not existing)
- sabayaon (not existing)

Also add gnome-photos to Suggests for GNOME-IMAGE (it's not ready yet,
but people might want to discover it).

Also remove a duplicate rhythmbox (was in Suggests whil already in
Recommends).
