### PR TITLE
Add libvirt to KVM and Xen patterns

### DIFF
--- a/data/KVM
+++ b/data/KVM
@@ -18,5 +18,6 @@ efont-unicode
 xorg-x11-fonts
 virt-viewer
 virt-manager
+libvirt
 libvirt-daemon-qemu
 -Prc:

--- a/data/XEN
+++ b/data/XEN
@@ -16,6 +16,7 @@ xen-doc-html
 xterm
 yast2-vm
 virt-viewer
+libvirt
 libvirt-daemon-xen
 -Prc:
 +Psg:


### PR DESCRIPTION
The libvirt package needs to be on the media to ensure the
libvirt daemon is preserved on upgrade.  Add it to the KVM and
Xen patterns.
