### PR TITLE
Preffer the systemd-logger (journald) instead of rsyslog.

### DIFF
--- a/data/BASIS
+++ b/data/BASIS
@@ -65,6 +65,5 @@ lilo
 
 +Psg:
 grub
-// default old syslog daemon
-rsyslog
+systemd-logger
 -Psg:


### PR DESCRIPTION
This is for after 13.1 not prior so we can copy it over if we have more pattern fixes.

Also I am not sure if this is sufficient to make it default so if there is more actions required then tell me :)
