### PR TITLE
prefer kmod-compat instead of module-init-tools

### DIFF
--- a/data/BASIS
+++ b/data/BASIS
@@ -8,7 +8,7 @@ kbd
 #endif
 kernel
 mkinitrd
-module-init-tools
+kmod-compat
 netcfg
 openssh
 procps


### PR DESCRIPTION
This is the current implementation of module-init-tools 
