### PR TITLE
microcode_ctl is long gone, ucode-intel takes its place for now.

### DIFF
--- a/data/ENHANCED-BASIS
+++ b/data/ENHANCED-BASIS
@@ -106,7 +106,7 @@ dmidecode
 acpica
 #endif
 #if defined(__i386__) || defined(__x86_64__)
-microcode_ctl
+ucode-intel
 #endif
 pm-utils
 postfix


### PR DESCRIPTION
the amd microcode is part of kernel-firmware currently
